### PR TITLE
Fix mem::uninitialized() warnings in tests

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -190,7 +190,7 @@ fn get_flatbuffer<'a, T: flatbuffers::Follow<'a> + 'a>(
 #[cfg(test)]
 mod tests {
     use crate::{ffi, interface::RLBotInterface};
-    use std::{error::Error, mem};
+    use std::{error::Error, mem::MaybeUninit};
 
     #[test]
     #[ignore = "compile-only test"]
@@ -202,7 +202,8 @@ mod tests {
         assert_send(ffi::FieldInfo::default());
         assert_send(ffi::BallPredictionPacket::default());
 
-        let interface: RLBotInterface = unsafe { mem::uninitialized() };
+        let interface: MaybeUninit<RLBotInterface> = MaybeUninit::uninit();
+        let interface = unsafe { interface.assume_init() }; // undefined behavior!
         assert_send(interface.update_live_data_packet_flatbuffer());
         assert_send(interface.update_rigid_body_tick_flatbuffer());
         assert_send(interface.update_field_info_flatbuffer());

--- a/src/rlbot.rs
+++ b/src/rlbot.rs
@@ -115,14 +115,15 @@ impl RLBot {
 #[cfg(test)]
 mod tests {
     use crate::rlbot::RLBot;
-    use std::{error::Error, mem};
+    use std::{error::Error, mem::MaybeUninit};
 
     #[test]
     #[ignore = "compile-only test"]
     fn game_data_is_send() -> Result<(), Box<dyn Error>> {
         fn assert_send<T: Send + 'static>(_: T) {}
 
-        let rlbot: RLBot = unsafe { mem::uninitialized() };
+        let rlbot: MaybeUninit<RLBot> = MaybeUninit::uninit();
+        let rlbot = unsafe { rlbot.assume_init() }; // undefined behavior!
         assert_send(rlbot.physicist().next_flat()?);
         assert_send(rlbot.packeteer().next()?);
         assert_send(rlbot.packeteer().next_flatbuffer()?);


### PR DESCRIPTION
These are compile-only tests, so it is acceptable that these variables really are uninitialized.