### PR TITLE
Updated the bindgen documentation link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This will update the `src/rlbot_generated.rs` file.
 
 Bindings are generated with [rust-bindgen]. Those docs are required reading.
 
-[rust-bindgen]: https://rust-lang-nursery.github.io/rust-bindgen/
+[rust-bindgen]: https://rust-lang.github.io/rust-bindgen/
 
 After bindgen and its prerequisites are installed and working, run this
 delightfully short command:


### PR DESCRIPTION
Bindgen documentation moved from the rust-lang-nursery to the main rust-lang repo.
[for information] I did not have pre-commit installed at the time of this change.