### PR TITLE
Fix memory leak between the RLBot library and rlbot-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rlbot"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2018"
 authors = ["John Simon <john@whatisaph.one>"]
 description = "RLBot bindings for Rust"

--- a/examples/gravity.rs
+++ b/examples/gravity.rs
@@ -16,38 +16,38 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut packets = rlbot.packeteer();
     let mut i = 0;
     loop {
-        let packet = packets.next_flatbuffer()?;
+        let packet = packets.next()?;
 
         // Check that the game is not showing a replay.
         // Also don't set state on every frame, that can make it laggy.
-        if packet.gameInfo().unwrap().isRoundActive() && i % 8 == 0 {
+        if packet.game_info.is_round_active && i % 8 == 0 {
             rlbot.set_game_state(&get_desired_state(packet))?;
         }
         i += 1;
     }
 }
 
-fn get_desired_state(packet: rlbot::flat::GameTickPacket<'_>) -> rlbot::DesiredGameState {
-    let ball_phys = packet.ball().unwrap().physics().unwrap();
-    let ball_loc = ball_phys.location().unwrap();
-    let ball_loc = Point3::new(ball_loc.x(), ball_loc.y(), ball_loc.z());
+fn get_desired_state(packet: rlbot::GameTickPacket) -> rlbot::DesiredGameState {
+    let ball_phys = &packet.ball.as_ref().unwrap().physics;
+    let ball_loc = &ball_phys.location;
+    let ball_loc = Point3::new(ball_loc.x, ball_loc.y, ball_loc.z);
 
     let mut desired_game_state = rlbot::DesiredGameState::new();
 
-    for i in 0..packet.players().unwrap().len() {
-        let car = packet.players().unwrap().get(i);
-        let car_phys = car.physics().unwrap();
-        let car_loc = car_phys.location().unwrap();
-        let v = car_phys.velocity().unwrap();
+    for i in 0..packet.players.len() {
+        let car = packet.players.get(i).unwrap();
+        let car_phys = &car.physics;
+        let car_loc = &car_phys.location;
+        let v = &car_phys.velocity;
         let a = gravitate_towards_ball(&ball_loc, car_loc);
 
         // Note: You can ordinarily just use `na::Vector3::new(x, y, z)` here. There's a
         // cargo build oddity which prevents that from working in code inside the
         // `examples/` directory.
         let new_velocity = rlbot::Vector3Partial::new()
-            .x(v.x() + a.x)
-            .y(v.y() + a.y)
-            .z(v.z() + a.z);
+            .x(v.x + a.x)
+            .y(v.y + a.y)
+            .z(v.z + a.z);
 
         let physics = rlbot::DesiredPhysics::new().velocity(new_velocity);
         let car_state = rlbot::DesiredCarState::new().physics(physics);
@@ -59,8 +59,8 @@ fn get_desired_state(packet: rlbot::flat::GameTickPacket<'_>) -> rlbot::DesiredG
 
 /// Generate an acceleration to apply to the car towards the ball, as if the
 /// ball exerted a large gravitational force
-fn gravitate_towards_ball(ball_loc: &Point3<f32>, car_loc: &rlbot::flat::Vector3) -> Vector3<f32> {
-    let car_loc = Point3::new(car_loc.x(), car_loc.y(), car_loc.z());
+fn gravitate_towards_ball(ball_loc: &Point3<f32>, car_loc: &rlbot::Vector3) -> Vector3<f32> {
+    let car_loc = Point3::new(car_loc.x, car_loc.y, car_loc.z);
     let ball_delta = ball_loc - car_loc;
     let distance = ball_delta.norm();
     let k = 1_000_000.0;

--- a/examples/gravity_flatbuffer.rs
+++ b/examples/gravity_flatbuffer.rs
@@ -5,7 +5,7 @@
 #![warn(clippy::all)]
 
 use na::{Unit, Vector3};
-use rlbot::flat;
+use rlbot::{flat, GameTickPacket, PlayerInfo};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -17,11 +17,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut packets = rlbot.packeteer();
     let mut i = 0;
     loop {
-        let packet = packets.next_flatbuffer()?;
+        let packet = packets.next()?;
 
         // Check that the game is not showing a replay.
         // Also don't set state on every frame, that can make it laggy.
-        if packet.gameInfo().unwrap().isRoundActive() && i % 8 == 0 {
+        if packet.game_info.is_round_active && i % 8 == 0 {
             let desired_state = get_desired_state(&packet);
             rlbot
                 .interface()
@@ -31,27 +31,27 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn get_desired_state<'a>(packet: &flat::GameTickPacket<'_>) -> flatbuffers::FlatBufferBuilder<'a> {
-    let ball = packet.ball().expect("Missing ball");
-    let ball_phys = ball.physics().expect("Missing ball physics");
-    let flat_ball_loc = ball_phys.location().expect("Missing ball location");
-    let ball_loc = Vector3::new(flat_ball_loc.x(), flat_ball_loc.y(), flat_ball_loc.z());
-    let cars = packet.players().expect("Missing players");
+fn get_desired_state<'a>(packet: &GameTickPacket) -> flatbuffers::FlatBufferBuilder<'a> {
+    let ball = packet.ball.as_ref().expect("Missing ball");
+    let ball_phys = &ball.physics;
+    let ball_loc = &ball_phys.location;
+    let ball_loc = Vector3::new(ball_loc.x, ball_loc.y, ball_loc.z);
+    let cars = &packet.players;
 
     let mut builder = flatbuffers::FlatBufferBuilder::new_with_capacity(1024);
 
     let mut car_offsets = Vec::with_capacity(cars.len());
     let mut i = 0;
     while i < cars.len() {
-        let car = cars.get(i);
-        let car_phys = car.physics().expect("Missing player physics");
-        let v = car_phys.velocity().expect("Missing player velocity");
-        let a = gravitate_towards_ball(&ball_loc, &car);
+        let car = cars.get(i).expect("Missing car");
+        let car_phys = &car.physics;
+        let v = &car_phys.velocity;
+        let a = gravitate_towards_ball(&ball_loc, car);
 
         let new_velocity = flat::Vector3Partial::create(&mut builder, &flat::Vector3PartialArgs {
-            x: Some(&flat::Float::new(v.x() + a.x)),
-            y: Some(&flat::Float::new(v.y() + a.y)),
-            z: Some(&flat::Float::new(v.z() + a.z)),
+            x: Some(&flat::Float::new(v.x + a.x)),
+            y: Some(&flat::Float::new(v.y + a.y)),
+            z: Some(&flat::Float::new(v.z + a.z)),
         });
 
         let physics = flat::DesiredPhysics::create(&mut builder, &flat::DesiredPhysicsArgs {
@@ -80,10 +80,10 @@ fn get_desired_state<'a>(packet: &flat::GameTickPacket<'_>) -> flatbuffers::Flat
 
 /// Generate an acceleration to apply to the car towards the ball, as if the
 /// ball exerted a large gravitational force
-fn gravitate_towards_ball(ball_loc: &Vector3<f32>, car: &flat::PlayerInfo<'_>) -> Vector3<f32> {
-    let car_phys = car.physics().expect("Missing player physics");
-    let flat_car_loc = car_phys.location().expect("Missing player location");
-    let car_loc = Vector3::new(flat_car_loc.x(), flat_car_loc.y(), flat_car_loc.z());
+fn gravitate_towards_ball(ball_loc: &Vector3<f32>, car: &PlayerInfo) -> Vector3<f32> {
+    let car_phys = &car.physics;
+    let car_loc = &car_phys.location;
+    let car_loc = Vector3::new(car_loc.x, car_loc.y, car_loc.z);
     let ball_delta = ball_loc - car_loc;
     let distance = ball_delta.norm();
     let k = 1_000_000.0;

--- a/examples/rendering.rs
+++ b/examples/rendering.rs
@@ -17,8 +17,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut packets = rlbot.packeteer();
     loop {
-        let packet = packets.next_flatbuffer()?;
-        let mut total_ms = (packet.gameInfo().unwrap().secondsElapsed() * 1000.0) as i32;
+        let packet = packets.next()?;
+        let mut total_ms = (packet.game_info.seconds_elapsed * 1000.0) as i32;
         let ms = total_ms % 1000;
         total_ms -= ms;
         let sec = total_ms / 1000 % 60;

--- a/examples/simple_flatbuffer.rs
+++ b/examples/simple_flatbuffer.rs
@@ -7,7 +7,7 @@
 #![warn(clippy::all)]
 
 use na::Vector2;
-use rlbot::flat;
+use rlbot::{flat, GameTickPacket};
 use std::{error::Error, f32::consts::PI};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -18,12 +18,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut packets = rlbot.packeteer();
     loop {
-        let packet = packets.next_flatbuffer()?;
+        let packet = packets.next()?;
 
         // check that match is started and not showing a replay.
         // `packets.next_flatbuffer()` sleeps until the next packet is
         // available, so this loop will not roast your CPU :)
-        if packet.gameInfo().unwrap().isRoundActive() {
+        if packet.game_info.is_round_active {
             let input = get_input(&packet);
             rlbot
                 .interface()
@@ -32,21 +32,21 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn get_input<'a>(packet: &flat::GameTickPacket<'_>) -> flatbuffers::FlatBufferBuilder<'a> {
-    let ball = packet.ball().expect("Missing ball");
-    let ball_phys = ball.physics().expect("Missing ball physics");
-    let flat_ball_loc = ball_phys.location().expect("Missing ball location");
-    let ball_loc = Vector2::new(flat_ball_loc.x(), flat_ball_loc.y());
+fn get_input<'a>(packet: &GameTickPacket) -> flatbuffers::FlatBufferBuilder<'a> {
+    let ball = packet.ball.as_ref().expect("Missing ball");
+    let ball_phys = &ball.physics;
+    let ball_loc_3d = &ball_phys.location;
+    let ball_loc = Vector2::new(ball_loc_3d.x, ball_loc_3d.y);
 
-    let car = packet.players().expect("Missing players").get(0);
-    let car_phys = car.physics().expect("Missing player physics");
-    let flat_car_loc = car_phys.location().expect("Missing player location");
-    let car_loc = Vector2::new(flat_car_loc.x(), flat_car_loc.y());
+    let car = packet.players.get(0).expect("Missing player info");
+    let car_phys = &car.physics;
+    let car_loc_3d = &car_phys.location;
+    let car_loc = Vector2::new(car_loc_3d.x, car_loc_3d.y);
 
     let offset = ball_loc - car_loc;
     let desired_yaw = f32::atan2(offset.y, offset.x);
-    let flat_car_rot = car_phys.rotation().expect("Missing player rotation");
-    let steer = desired_yaw - flat_car_rot.yaw();
+    let car_rot = &car_phys.rotation;
+    let steer = desired_yaw - car_rot.yaw;
 
     let player_index = 0;
     let controller_state_args = flat::ControllerStateArgs {

--- a/src/dll.rs
+++ b/src/dll.rs
@@ -61,7 +61,7 @@ pub struct RLBotCoreInterface {
     pub update_field_info: UpdateFieldInfo,
     update_live_data_packet_flatbuffer_raw: UpdateLiveDataPacketFlatbuffer,
     pub update_live_data_packet: UpdateLiveDataPacket,
-    pub update_rigid_body_tick_flatbuffer: UpdateRigidBodyTickFlatbuffer,
+    update_rigid_body_tick_flatbuffer_raw: UpdateRigidBodyTickFlatbuffer,
     pub update_rigid_body_tick: UpdateRigidBodyTick,
     pub free: Free,
     pub set_game_state: SetGameState,
@@ -98,6 +98,10 @@ impl RLBotCoreInterface {
         self.copy_and_free_byte_buffer(|| (self.update_live_data_packet_flatbuffer_raw)())
     }
 
+    pub fn update_rigid_body_tick_flatbuffer(&self) -> Option<Vec<u8>> {
+        self.copy_and_free_byte_buffer(|| (self.update_rigid_body_tick_flatbuffer_raw)())
+    }
+
     pub fn load(rlbot_dll_directory: Option<&Path>) -> io::Result<RLBotCoreInterface> {
         if INITIALIZED.swap(true, Ordering::SeqCst) {
             panic!("RLBot can only be initialized once");
@@ -120,7 +124,7 @@ impl RLBotCoreInterface {
                 update_live_data_packet_flatbuffer_raw: *library
                     .get(b"UpdateLiveDataPacketFlatbuffer")?,
                 update_live_data_packet: *library.get(b"UpdateLiveDataPacket")?,
-                update_rigid_body_tick_flatbuffer: *library
+                update_rigid_body_tick_flatbuffer_raw: *library
                     .get(b"UpdateRigidBodyTickFlatbuffer")?,
                 update_rigid_body_tick: *library.get(b"UpdateRigidBodyTick")?,
                 free: *library.get(b"Free")?,

--- a/src/dll.rs
+++ b/src/dll.rs
@@ -74,7 +74,7 @@ pub struct RLBotCoreInterface {
     pub update_player_input_flatbuffer: UpdatePlayerInputFlatbuffer,
     pub render_group: RenderGroup,
     pub is_initialized: IsInitialized,
-    pub get_ball_prediction: GetBallPrediction,
+    get_ball_prediction_raw: GetBallPrediction,
     pub get_ball_prediction_struct: GetBallPredictionStruct,
 }
 
@@ -100,6 +100,10 @@ impl RLBotCoreInterface {
 
     pub fn update_rigid_body_tick_flatbuffer(&self) -> Option<Vec<u8>> {
         self.copy_and_free_byte_buffer(|| (self.update_rigid_body_tick_flatbuffer_raw)())
+    }
+
+    pub fn get_ball_prediction(&self) -> Option<Vec<u8>> {
+        self.copy_and_free_byte_buffer(|| (self.get_ball_prediction_raw)())
     }
 
     pub fn load(rlbot_dll_directory: Option<&Path>) -> io::Result<RLBotCoreInterface> {
@@ -137,7 +141,7 @@ impl RLBotCoreInterface {
                 update_player_input_flatbuffer: *library.get(b"UpdatePlayerInputFlatbuffer")?,
                 render_group: *library.get(b"RenderGroup")?,
                 is_initialized: *library.get(b"IsInitialized")?,
-                get_ball_prediction: *library.get(b"GetBallPrediction")?,
+                get_ball_prediction_raw: *library.get(b"GetBallPrediction")?,
                 get_ball_prediction_struct: *library.get(b"GetBallPredictionStruct")?,
             })
         }

--- a/src/ffi_impls.rs
+++ b/src/ffi_impls.rs
@@ -1,4 +1,5 @@
-use crate::ffi;
+use crate::{ffi, ffi::ByteBuffer};
+use std::ptr;
 
 impl ffi::LiveDataPacket {
     /// Yields the [`PlayerInfo`](ffi::PlayerInfo) for each player in the match.
@@ -73,5 +74,22 @@ impl ffi::PlayerConfiguration {
         for (i, cp) in name.encode_utf16().enumerate() {
             self.Name[i] = cp;
         }
+    }
+}
+
+impl From<ByteBuffer> for Option<Vec<u8>> {
+    fn from(byte_buffer: ByteBuffer) -> Self {
+        let len = byte_buffer.size as usize;
+        if len == 0 || byte_buffer.ptr.is_null() {
+            return None;
+        }
+
+        let mut buf = Vec::with_capacity(len);
+        unsafe {
+            ptr::copy_nonoverlapping(byte_buffer.ptr as *const u8, buf.as_mut_ptr(), len);
+            buf.set_len(len);
+        }
+
+        Some(buf)
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -231,6 +231,17 @@ pub struct RigidBodyTick {
     pub(crate) _non_exhaustive: (),
 }
 
+pub struct PredictionSlice {
+    pub game_seconds: f32,
+    pub physics: Physics,
+    pub(crate) _non_exhaustive: (),
+}
+
+pub struct BallPrediction {
+    pub slices: SmallVec<[PredictionSlice; 512]>,
+    pub(crate) _non_exhaustive: (),
+}
+
 pub(crate) fn build_update_player_input(
     player_index: i32,
     controller_state: &ControllerState,

--- a/src/game.rs
+++ b/src/game.rs
@@ -205,6 +205,32 @@ pub struct FieldInfo {
     pub(crate) _non_exhaustive: (),
 }
 
+pub struct RigidBodyState {
+    pub frame: i32,
+    pub location: Vector3,
+    pub rotation: Quaternion,
+    pub velocity: Vector3,
+    pub angular_velocity: Vector3,
+    pub(crate) _non_exhaustive: (),
+}
+
+pub struct PlayerRigidBodyState {
+    pub state: RigidBodyState,
+    pub input: ControllerState,
+    pub(crate) _non_exhaustive: (),
+}
+
+pub struct BallRigidBodyState {
+    pub state: Option<RigidBodyState>,
+    pub(crate) _non_exhaustive: (),
+}
+
+pub struct RigidBodyTick {
+    pub ball: Option<BallRigidBodyState>,
+    pub players: SmallVec<[PlayerRigidBodyState; 10]>,
+    pub(crate) _non_exhaustive: (),
+}
+
 pub(crate) fn build_update_player_input(
     player_index: i32,
     controller_state: &ControllerState,

--- a/src/game.rs
+++ b/src/game.rs
@@ -35,6 +35,7 @@ pub struct Vector3 {
 
 /// Expresses the rotation state of an object in Euler angles, with values in
 /// radians.
+#[derive(Default)]
 pub struct Rotator {
     pub pitch: f32,
     pub yaw: f32,

--- a/src/game.rs
+++ b/src/game.rs
@@ -186,6 +186,25 @@ pub struct GameTickPacket {
     pub(crate) _non_exhaustive: (),
 }
 
+pub struct GoalInfo {
+    pub team_num: i32,
+    pub location: Vector3,
+    pub direction: Vector3,
+    pub(crate) _non_exhaustive: (),
+}
+
+pub struct BoostPad {
+    pub location: Vector3,
+    pub full_boost: bool,
+    pub(crate) _non_exhaustive: (),
+}
+
+pub struct FieldInfo {
+    pub boost_pads: SmallVec<[BoostPad; 64]>,
+    pub goals: SmallVec<[GoalInfo; 256]>,
+    pub(crate) _non_exhaustive: (),
+}
+
 pub(crate) fn build_update_player_input(
     player_index: i32,
     controller_state: &ControllerState,

--- a/src/game_deserialize.rs
+++ b/src/game_deserialize.rs
@@ -1,5 +1,27 @@
 use crate::{flat, game::*, utils::flat_vector_iter};
 
+impl From<flat::GameTickPacket<'_>> for GameTickPacket {
+    fn from(packet: flat::GameTickPacket<'_>) -> Self {
+        Self {
+            players: flat_vector_iter(packet.players().unwrap())
+                .map(PlayerInfo::from)
+                .collect(),
+            boost_pad_states: flat_vector_iter(packet.boostPadStates().unwrap())
+                .map(BoostPadState::from)
+                .collect(),
+            ball: packet.ball().map(BallInfo::from),
+            game_info: packet.gameInfo().unwrap().into(),
+            tile_information: packet
+                .tileInformation()
+                .map(|ti| flat_vector_iter(ti).map(DropshotTile::from).collect()),
+            teams: flat_vector_iter(packet.teams().unwrap())
+                .map(TeamInfo::from)
+                .collect(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
 pub fn deserialize_game_tick_packet(packet: flat::GameTickPacket<'_>) -> GameTickPacket {
     GameTickPacket {
         players: flat_vector_iter(packet.players().unwrap())
@@ -22,6 +44,25 @@ pub fn deserialize_game_tick_packet(packet: flat::GameTickPacket<'_>) -> GameTic
     }
 }
 
+impl From<flat::PlayerInfo<'_>> for PlayerInfo {
+    fn from(info: flat::PlayerInfo<'_>) -> Self {
+        Self {
+            physics: info.physics().unwrap().into(),
+            score_info: info.scoreInfo().unwrap().into(),
+            is_demolished: info.isDemolished(),
+            has_wheel_contact: info.hasWheelContact(),
+            is_supersonic: info.isSupersonic(),
+            is_bot: info.isBot(),
+            jumped: info.jumped(),
+            double_jumped: info.doubleJumped(),
+            name: info.name().unwrap().to_string(),
+            team: info.team(),
+            boost: info.boost(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
 fn deserialize_player_info(info: flat::PlayerInfo<'_>) -> PlayerInfo {
     PlayerInfo {
         physics: deserialize_physics(info.physics().unwrap()),
@@ -39,11 +80,32 @@ fn deserialize_player_info(info: flat::PlayerInfo<'_>) -> PlayerInfo {
     }
 }
 
+impl From<flat::BoostPadState<'_>> for BoostPadState {
+    fn from(state: flat::BoostPadState<'_>) -> Self {
+        Self {
+            is_active: state.isActive(),
+            timer: state.timer(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
 fn deserialize_boost_pad_state(state: flat::BoostPadState<'_>) -> BoostPadState {
     BoostPadState {
         is_active: state.isActive(),
         timer: state.timer(),
         _non_exhaustive: (),
+    }
+}
+
+impl From<flat::BallInfo<'_>> for BallInfo {
+    fn from(info: flat::BallInfo<'_>) -> Self {
+        Self {
+            physics: info.physics().unwrap().into(),
+            latest_touch: info.latestTouch().map(Touch::from),
+            dropshot_info: info.dropShotInfo().map(DropshotBallInfo::from),
+            _non_exhaustive: (),
+        }
     }
 }
 
@@ -53,6 +115,18 @@ fn deserialize_ball_info(info: flat::BallInfo<'_>) -> BallInfo {
         latest_touch: info.latestTouch().map(deserialize_touch),
         dropshot_info: info.dropShotInfo().map(deserialize_dropshot_ball_info),
         _non_exhaustive: (),
+    }
+}
+
+impl From<flat::Physics<'_>> for Physics {
+    fn from(physics: flat::Physics<'_>) -> Self {
+        Self {
+            location: physics.location().unwrap().into(),
+            rotation: physics.rotation().unwrap().into(),
+            velocity: physics.velocity().unwrap().into(),
+            angular_velocity: physics.angularVelocity().unwrap().into(),
+            _non_exhaustive: (),
+        }
     }
 }
 
@@ -66,6 +140,16 @@ fn deserialize_physics(physics: flat::Physics<'_>) -> Physics {
     }
 }
 
+impl From<&flat::Vector3> for Vector3 {
+    fn from(vector3: &flat::Vector3) -> Self {
+        Self {
+            x: vector3.x(),
+            y: vector3.y(),
+            z: vector3.z(),
+        }
+    }
+}
+
 fn deserialize_vector3(vector3: &flat::Vector3) -> Vector3 {
     Vector3 {
         x: vector3.x(),
@@ -74,11 +158,34 @@ fn deserialize_vector3(vector3: &flat::Vector3) -> Vector3 {
     }
 }
 
+impl From<&flat::Rotator> for Rotator {
+    fn from(rotator: &flat::Rotator) -> Self {
+        Self {
+            pitch: rotator.pitch(),
+            yaw: rotator.yaw(),
+            roll: rotator.roll(),
+        }
+    }
+}
+
 fn deserialize_rotator(rotator: &flat::Rotator) -> Rotator {
     Rotator {
         pitch: rotator.pitch(),
         yaw: rotator.yaw(),
         roll: rotator.roll(),
+    }
+}
+
+impl From<flat::Touch<'_>> for Touch {
+    fn from(touch: flat::Touch<'_>) -> Self {
+        Self {
+            player_name: touch.playerName().unwrap().to_string(),
+            game_seconds: touch.gameSeconds(),
+            location: touch.location().unwrap().into(),
+            normal: touch.normal().unwrap().into(),
+            team: touch.team(),
+            _non_exhaustive: (),
+        }
     }
 }
 
@@ -93,12 +200,40 @@ fn deserialize_touch(touch: flat::Touch<'_>) -> Touch {
     }
 }
 
+impl From<flat::DropShotBallInfo<'_>> for DropshotBallInfo {
+    fn from(info: flat::DropShotBallInfo<'_>) -> Self {
+        Self {
+            absorbed_force: info.absorbedForce(),
+            damage_index: info.damageIndex(),
+            force_accum_recent: info.forceAccumRecent(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
 fn deserialize_dropshot_ball_info(info: flat::DropShotBallInfo<'_>) -> DropshotBallInfo {
     DropshotBallInfo {
         absorbed_force: info.absorbedForce(),
         damage_index: info.damageIndex(),
         force_accum_recent: info.forceAccumRecent(),
         _non_exhaustive: (),
+    }
+}
+
+impl From<flat::GameInfo<'_>> for GameInfo {
+    fn from(info: flat::GameInfo<'_>) -> Self {
+        Self {
+            seconds_elapsed: info.secondsElapsed(),
+            game_time_remaining: info.gameTimeRemaining(),
+            is_overtime: info.isOvertime(),
+            is_unlimited_time: info.isUnlimitedTime(),
+            is_round_active: info.isRoundActive(),
+            is_kickoff_pause: info.isKickoffPause(),
+            is_match_ended: info.isMatchEnded(),
+            world_gravity_z: info.worldGravityZ(),
+            game_speed: info.gameSpeed(),
+            _non_exhaustive: (),
+        }
     }
 }
 
@@ -117,10 +252,29 @@ fn deserialize_game_info(info: flat::GameInfo<'_>) -> GameInfo {
     }
 }
 
+impl From<flat::DropshotTile<'_>> for DropshotTile {
+    fn from(tile: flat::DropshotTile<'_>) -> Self {
+        Self {
+            tile_state: tile.tileState(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
 fn deserialize_dropshot_tile(tile: flat::DropshotTile<'_>) -> DropshotTile {
     DropshotTile {
         tile_state: tile.tileState(),
         _non_exhaustive: (),
+    }
+}
+
+impl From<flat::TeamInfo<'_>> for TeamInfo {
+    fn from(info: flat::TeamInfo<'_>) -> Self {
+        Self {
+            team_index: info.teamIndex(),
+            score: info.score(),
+            _non_exhaustive: (),
+        }
     }
 }
 
@@ -129,6 +283,21 @@ fn deserialize_team_info(info: flat::TeamInfo<'_>) -> TeamInfo {
         team_index: info.teamIndex(),
         score: info.score(),
         _non_exhaustive: (),
+    }
+}
+
+impl From<flat::ScoreInfo<'_>> for ScoreInfo {
+    fn from(info: flat::ScoreInfo<'_>) -> Self {
+        Self {
+            score: info.score(),
+            goals: info.goals(),
+            own_goals: info.ownGoals(),
+            assists: info.assists(),
+            saves: info.saves(),
+            shots: info.shots(),
+            demolitions: info.demolitions(),
+            _non_exhaustive: (),
+        }
     }
 }
 

--- a/src/game_deserialize.rs
+++ b/src/game_deserialize.rs
@@ -22,6 +22,8 @@ impl From<flat::GameTickPacket<'_>> for GameTickPacket {
     }
 }
 
+#[allow(unused)]
+#[deprecated(note = "Use The From trait implementation instead")]
 pub fn deserialize_game_tick_packet(packet: flat::GameTickPacket<'_>) -> GameTickPacket {
     GameTickPacket {
         players: flat_vector_iter(packet.players().unwrap())

--- a/src/game_deserialize.rs
+++ b/src/game_deserialize.rs
@@ -274,3 +274,24 @@ impl From<flat::RigidBodyTick<'_>> for RigidBodyTick {
         }
     }
 }
+
+impl From<flat::PredictionSlice<'_>> for PredictionSlice {
+    fn from(slice: flat::PredictionSlice<'_>) -> Self {
+        Self {
+            game_seconds: slice.gameSeconds(),
+            physics: slice.physics().unwrap().into(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<flat::BallPrediction<'_>> for BallPrediction {
+    fn from(ball_prediction: flat::BallPrediction<'_>) -> Self {
+        Self {
+            slices: flat_vector_iter(ball_prediction.slices().unwrap())
+                .map(PredictionSlice::from)
+                .collect(),
+            _non_exhaustive: (),
+        }
+    }
+}

--- a/src/game_deserialize.rs
+++ b/src/game_deserialize.rs
@@ -168,3 +168,38 @@ impl From<flat::ScoreInfo<'_>> for ScoreInfo {
         }
     }
 }
+
+impl From<flat::GoalInfo<'_>> for GoalInfo {
+    fn from(goal_info: flat::GoalInfo<'_>) -> Self {
+        Self {
+            team_num: goal_info.teamNum(),
+            location: goal_info.location().unwrap().into(),
+            direction: goal_info.direction().unwrap().into(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<flat::BoostPad<'_>> for BoostPad {
+    fn from(boost_pad: flat::BoostPad<'_>) -> Self {
+        Self {
+            location: boost_pad.location().unwrap().into(),
+            full_boost: boost_pad.isFullBoost(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<flat::FieldInfo<'_>> for FieldInfo {
+    fn from(info: flat::FieldInfo<'_>) -> Self {
+        Self {
+            boost_pads: flat_vector_iter(info.boostPads().unwrap())
+                .map(BoostPad::from)
+                .collect(),
+            goals: flat_vector_iter(info.goals().unwrap())
+                .map(GoalInfo::from)
+                .collect(),
+            _non_exhaustive: (),
+        }
+    }
+}

--- a/src/game_deserialize.rs
+++ b/src/game_deserialize.rs
@@ -22,30 +22,6 @@ impl From<flat::GameTickPacket<'_>> for GameTickPacket {
     }
 }
 
-#[allow(unused)]
-#[deprecated(note = "Use The From trait implementation instead")]
-pub fn deserialize_game_tick_packet(packet: flat::GameTickPacket<'_>) -> GameTickPacket {
-    GameTickPacket {
-        players: flat_vector_iter(packet.players().unwrap())
-            .map(deserialize_player_info)
-            .collect(),
-        boost_pad_states: flat_vector_iter(packet.boostPadStates().unwrap())
-            .map(deserialize_boost_pad_state)
-            .collect(),
-        ball: packet.ball().map(deserialize_ball_info),
-        game_info: deserialize_game_info(packet.gameInfo().unwrap()),
-        tile_information: packet.tileInformation().map(|ti| {
-            flat_vector_iter(ti)
-                .map(deserialize_dropshot_tile)
-                .collect()
-        }),
-        teams: flat_vector_iter(packet.teams().unwrap())
-            .map(deserialize_team_info)
-            .collect(),
-        _non_exhaustive: (),
-    }
-}
-
 impl From<flat::PlayerInfo<'_>> for PlayerInfo {
     fn from(info: flat::PlayerInfo<'_>) -> Self {
         Self {
@@ -65,23 +41,6 @@ impl From<flat::PlayerInfo<'_>> for PlayerInfo {
     }
 }
 
-fn deserialize_player_info(info: flat::PlayerInfo<'_>) -> PlayerInfo {
-    PlayerInfo {
-        physics: deserialize_physics(info.physics().unwrap()),
-        score_info: deserialize_score_info(info.scoreInfo().unwrap()),
-        is_demolished: info.isDemolished(),
-        has_wheel_contact: info.hasWheelContact(),
-        is_supersonic: info.isSupersonic(),
-        is_bot: info.isBot(),
-        jumped: info.jumped(),
-        double_jumped: info.doubleJumped(),
-        name: info.name().unwrap().to_string(),
-        team: info.team(),
-        boost: info.boost(),
-        _non_exhaustive: (),
-    }
-}
-
 impl From<flat::BoostPadState<'_>> for BoostPadState {
     fn from(state: flat::BoostPadState<'_>) -> Self {
         Self {
@@ -89,14 +48,6 @@ impl From<flat::BoostPadState<'_>> for BoostPadState {
             timer: state.timer(),
             _non_exhaustive: (),
         }
-    }
-}
-
-fn deserialize_boost_pad_state(state: flat::BoostPadState<'_>) -> BoostPadState {
-    BoostPadState {
-        is_active: state.isActive(),
-        timer: state.timer(),
-        _non_exhaustive: (),
     }
 }
 
@@ -108,15 +59,6 @@ impl From<flat::BallInfo<'_>> for BallInfo {
             dropshot_info: info.dropShotInfo().map(DropshotBallInfo::from),
             _non_exhaustive: (),
         }
-    }
-}
-
-fn deserialize_ball_info(info: flat::BallInfo<'_>) -> BallInfo {
-    BallInfo {
-        physics: deserialize_physics(info.physics().unwrap()),
-        latest_touch: info.latestTouch().map(deserialize_touch),
-        dropshot_info: info.dropShotInfo().map(deserialize_dropshot_ball_info),
-        _non_exhaustive: (),
     }
 }
 
@@ -132,16 +74,6 @@ impl From<flat::Physics<'_>> for Physics {
     }
 }
 
-fn deserialize_physics(physics: flat::Physics<'_>) -> Physics {
-    Physics {
-        location: deserialize_vector3(physics.location().unwrap()),
-        rotation: deserialize_rotator(physics.rotation().unwrap()),
-        velocity: deserialize_vector3(physics.velocity().unwrap()),
-        angular_velocity: deserialize_vector3(physics.angularVelocity().unwrap()),
-        _non_exhaustive: (),
-    }
-}
-
 impl From<&flat::Vector3> for Vector3 {
     fn from(vector3: &flat::Vector3) -> Self {
         Self {
@@ -152,14 +84,6 @@ impl From<&flat::Vector3> for Vector3 {
     }
 }
 
-fn deserialize_vector3(vector3: &flat::Vector3) -> Vector3 {
-    Vector3 {
-        x: vector3.x(),
-        y: vector3.y(),
-        z: vector3.z(),
-    }
-}
-
 impl From<&flat::Rotator> for Rotator {
     fn from(rotator: &flat::Rotator) -> Self {
         Self {
@@ -167,14 +91,6 @@ impl From<&flat::Rotator> for Rotator {
             yaw: rotator.yaw(),
             roll: rotator.roll(),
         }
-    }
-}
-
-fn deserialize_rotator(rotator: &flat::Rotator) -> Rotator {
-    Rotator {
-        pitch: rotator.pitch(),
-        yaw: rotator.yaw(),
-        roll: rotator.roll(),
     }
 }
 
@@ -191,17 +107,6 @@ impl From<flat::Touch<'_>> for Touch {
     }
 }
 
-fn deserialize_touch(touch: flat::Touch<'_>) -> Touch {
-    Touch {
-        player_name: touch.playerName().unwrap().to_string(),
-        game_seconds: touch.gameSeconds(),
-        location: deserialize_vector3(touch.location().unwrap()),
-        normal: deserialize_vector3(touch.normal().unwrap()),
-        team: touch.team(),
-        _non_exhaustive: (),
-    }
-}
-
 impl From<flat::DropShotBallInfo<'_>> for DropshotBallInfo {
     fn from(info: flat::DropShotBallInfo<'_>) -> Self {
         Self {
@@ -210,15 +115,6 @@ impl From<flat::DropShotBallInfo<'_>> for DropshotBallInfo {
             force_accum_recent: info.forceAccumRecent(),
             _non_exhaustive: (),
         }
-    }
-}
-
-fn deserialize_dropshot_ball_info(info: flat::DropShotBallInfo<'_>) -> DropshotBallInfo {
-    DropshotBallInfo {
-        absorbed_force: info.absorbedForce(),
-        damage_index: info.damageIndex(),
-        force_accum_recent: info.forceAccumRecent(),
-        _non_exhaustive: (),
     }
 }
 
@@ -239,34 +135,12 @@ impl From<flat::GameInfo<'_>> for GameInfo {
     }
 }
 
-fn deserialize_game_info(info: flat::GameInfo<'_>) -> GameInfo {
-    GameInfo {
-        seconds_elapsed: info.secondsElapsed(),
-        game_time_remaining: info.gameTimeRemaining(),
-        is_overtime: info.isOvertime(),
-        is_unlimited_time: info.isUnlimitedTime(),
-        is_round_active: info.isRoundActive(),
-        is_kickoff_pause: info.isKickoffPause(),
-        is_match_ended: info.isMatchEnded(),
-        world_gravity_z: info.worldGravityZ(),
-        game_speed: info.gameSpeed(),
-        _non_exhaustive: (),
-    }
-}
-
 impl From<flat::DropshotTile<'_>> for DropshotTile {
     fn from(tile: flat::DropshotTile<'_>) -> Self {
         Self {
             tile_state: tile.tileState(),
             _non_exhaustive: (),
         }
-    }
-}
-
-fn deserialize_dropshot_tile(tile: flat::DropshotTile<'_>) -> DropshotTile {
-    DropshotTile {
-        tile_state: tile.tileState(),
-        _non_exhaustive: (),
     }
 }
 
@@ -277,14 +151,6 @@ impl From<flat::TeamInfo<'_>> for TeamInfo {
             score: info.score(),
             _non_exhaustive: (),
         }
-    }
-}
-
-fn deserialize_team_info(info: flat::TeamInfo<'_>) -> TeamInfo {
-    TeamInfo {
-        team_index: info.teamIndex(),
-        score: info.score(),
-        _non_exhaustive: (),
     }
 }
 
@@ -300,18 +166,5 @@ impl From<flat::ScoreInfo<'_>> for ScoreInfo {
             demolitions: info.demolitions(),
             _non_exhaustive: (),
         }
-    }
-}
-
-fn deserialize_score_info(info: flat::ScoreInfo<'_>) -> ScoreInfo {
-    ScoreInfo {
-        score: info.score(),
-        goals: info.goals(),
-        own_goals: info.ownGoals(),
-        assists: info.assists(),
-        saves: info.saves(),
-        shots: info.shots(),
-        demolitions: info.demolitions(),
-        _non_exhaustive: (),
     }
 }

--- a/src/game_deserialize.rs
+++ b/src/game_deserialize.rs
@@ -82,7 +82,7 @@ impl From<flat::Physics<'_>> for Physics {
     fn from(physics: flat::Physics<'_>) -> Self {
         Self {
             location: physics.location().unwrap().into(),
-            rotation: physics.rotation().unwrap().into(),
+            rotation: physics.rotation().map_or(Rotator::default(), Rotator::from),
             velocity: physics.velocity().unwrap().into(),
             angular_velocity: physics.angularVelocity().unwrap().into(),
             _non_exhaustive: (),

--- a/src/game_deserialize.rs
+++ b/src/game_deserialize.rs
@@ -1,5 +1,21 @@
 use crate::{flat, game::*, utils::flat_vector_iter};
 
+impl From<flat::ControllerState<'_>> for ControllerState {
+    fn from(state: flat::ControllerState<'_>) -> Self {
+        Self {
+            throttle: state.throttle(),
+            steer: state.steer(),
+            pitch: state.pitch(),
+            yaw: state.yaw(),
+            roll: state.roll(),
+            jump: state.jump(),
+            boost: state.boost(),
+            handbrake: state.handbrake(),
+            use_item: state.useItem(),
+        }
+    }
+}
+
 impl From<flat::GameTickPacket<'_>> for GameTickPacket {
     fn from(packet: flat::GameTickPacket<'_>) -> Self {
         Self {
@@ -90,6 +106,17 @@ impl From<&flat::Rotator> for Rotator {
             pitch: rotator.pitch(),
             yaw: rotator.yaw(),
             roll: rotator.roll(),
+        }
+    }
+}
+
+impl From<&flat::Quaternion> for Quaternion {
+    fn from(quaternion: &flat::Quaternion) -> Self {
+        Self {
+            x: quaternion.x(),
+            y: quaternion.y(),
+            z: quaternion.z(),
+            w: quaternion.w(),
         }
     }
 }
@@ -198,6 +225,50 @@ impl From<flat::FieldInfo<'_>> for FieldInfo {
                 .collect(),
             goals: flat_vector_iter(info.goals().unwrap())
                 .map(GoalInfo::from)
+                .collect(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<flat::RigidBodyState<'_>> for RigidBodyState {
+    fn from(state: flat::RigidBodyState<'_>) -> Self {
+        Self {
+            frame: state.frame(),
+            location: state.location().unwrap().into(),
+            rotation: state.rotation().unwrap().into(),
+            velocity: state.velocity().unwrap().into(),
+            angular_velocity: state.angularVelocity().unwrap().into(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<flat::PlayerRigidBodyState<'_>> for PlayerRigidBodyState {
+    fn from(state: flat::PlayerRigidBodyState<'_>) -> Self {
+        Self {
+            state: state.state().unwrap().into(),
+            input: state.input().unwrap().into(),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<flat::BallRigidBodyState<'_>> for BallRigidBodyState {
+    fn from(state: flat::BallRigidBodyState<'_>) -> Self {
+        Self {
+            state: state.state().map(RigidBodyState::from),
+            _non_exhaustive: (),
+        }
+    }
+}
+
+impl From<flat::RigidBodyTick<'_>> for RigidBodyTick {
+    fn from(tick: flat::RigidBodyTick<'_>) -> Self {
+        Self {
+            ball: tick.ball().map(BallRigidBodyState::from),
+            players: flat_vector_iter(tick.players().unwrap())
+                .map(PlayerRigidBodyState::from)
                 .collect(),
             _non_exhaustive: (),
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -45,7 +45,7 @@ pub fn init() -> Result<RLBot, Box<dyn Error>> {
 /// [`examples/simple`]: https://github.com/whatisaphone/rlbot-rust/blob/master/examples/simple.rs
 #[allow(clippy::needless_pass_by_value)]
 pub fn init_with_options(options: InitOptions) -> Result<RLBot, Box<dyn Error>> {
-    let rlbot_dll_directory = options.rlbot_dll_directory.as_ref().map(PathBuf::as_path);
+    let rlbot_dll_directory = options.rlbot_dll_directory.as_deref();
 
     let dll = RLBotCoreInterface::load(rlbot_dll_directory)?;
     wait_for_initialized(&dll)?;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -33,8 +33,9 @@ impl RLBotInterface {
     /// if any. Consider using [`packeteer`](RLBot::packeteer) instead for
     /// a more convenient interface.
     pub fn update_live_data_packet_flatbuffer(&self) -> Option<GameTickPacket> {
-        let byte_buffer = (self.dll.update_live_data_packet_flatbuffer)();
-        get_flatbuffer::<flat::GameTickPacket<'_>>(byte_buffer).map(From::from)
+        self.dll
+            .update_live_data_packet_flatbuffer()
+            .map(|buf| flatbuffers::get_root::<flat::GameTickPacket<'_>>(&buf).into())
     }
 
     /// Grabs the current [`LiveDataPacket`](ffi::LiveDataPacket) from RLBot.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::{dll::RLBotCoreInterface, error::RLBotError, ffi, flat};
+use crate::{dll::RLBotCoreInterface, error::RLBotError, ffi, flat, game::*};
 use std::{
     os::raw::{c_int, c_void},
     ptr::null_mut,
@@ -32,9 +32,9 @@ impl RLBotInterface {
     /// Grabs the current [`flat::GameTickPacket`] from RLBot,
     /// if any. Consider using [`packeteer`](RLBot::packeteer) instead for
     /// a more convenient interface.
-    pub fn update_live_data_packet_flatbuffer<'fb>(&self) -> Option<flat::GameTickPacket<'fb>> {
+    pub fn update_live_data_packet_flatbuffer(&self) -> Option<GameTickPacket> {
         let byte_buffer = (self.dll.update_live_data_packet_flatbuffer)();
-        get_flatbuffer::<flat::GameTickPacket<'_>>(byte_buffer)
+        get_flatbuffer::<flat::GameTickPacket<'_>>(byte_buffer).map(From::from)
     }
 
     /// Grabs the current [`LiveDataPacket`](ffi::LiveDataPacket) from RLBot.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -15,9 +15,10 @@ impl RLBotInterface {
     }
 
     /// Grabs the current [`flat::FieldInfo`] from RLBot, if any
-    pub fn update_field_info_flatbuffer<'fb>(&self) -> Option<flat::FieldInfo<'fb>> {
-        let byte_buffer = (self.dll.update_field_info_flatbuffer)();
-        get_flatbuffer::<flat::FieldInfo<'_>>(byte_buffer)
+    pub fn update_field_info_flatbuffer(&self) -> Option<FieldInfo> {
+        self.dll
+            .update_field_info_flatbuffer()
+            .map(|buf| flatbuffers::get_root::<flat::FieldInfo<'_>>(&buf).into())
     }
 
     /// Grabs the current [`ffi::FieldInfo`] from RLBot

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -148,9 +148,10 @@ impl RLBotInterface {
     ///
     /// Note that this method requires the framework's `BallPrediction.exe` to
     /// be running in the background.
-    pub fn get_ball_prediction<'fb>(&self) -> Option<flat::BallPrediction<'fb>> {
-        let byte_buffer = (self.dll.get_ball_prediction)();
-        get_flatbuffer::<flat::BallPrediction<'_>>(byte_buffer)
+    pub fn get_ball_prediction(&self) -> Option<BallPrediction> {
+        self.dll
+            .get_ball_prediction()
+            .map(|buf| flatbuffers::get_root::<flat::BallPrediction<'_>>(&buf).into())
     }
 
     /// Gets the framework's current prediction of ball motion as a struct.
@@ -176,6 +177,7 @@ fn core_result(status: ffi::RLBotCoreStatus) -> Result<(), RLBotError> {
     }
 }
 
+#[allow(unused)]
 fn get_flatbuffer<'a, T: flatbuffers::Follow<'a> + 'a>(
     byte_buffer: ffi::ByteBuffer,
 ) -> Option<T::Inner> {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -54,9 +54,10 @@ impl RLBotInterface {
     }
 
     /// Grabs the current physics tick as a FlatBuffer table.
-    pub fn update_rigid_body_tick_flatbuffer<'fb>(&self) -> Option<flat::RigidBodyTick<'fb>> {
-        let byte_buffer = (self.dll.update_rigid_body_tick_flatbuffer)();
-        get_flatbuffer::<flat::RigidBodyTick<'_>>(byte_buffer)
+    pub fn update_rigid_body_tick_flatbuffer(&self) -> Option<RigidBodyTick> {
+        self.dll
+            .update_rigid_body_tick_flatbuffer()
+            .map(|buf| flatbuffers::get_root::<flat::RigidBodyTick<'_>>(&buf).into())
     }
 
     /// Grabs the current physics tick as a struct.

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -2,7 +2,6 @@ use crate::{dll::RLBotCoreInterface, error::RLBotError, ffi, flat, game::*};
 use std::{
     os::raw::{c_int, c_void},
     ptr::null_mut,
-    slice,
 };
 
 pub struct RLBotInterface {
@@ -175,21 +174,6 @@ fn core_result(status: ffi::RLBotCoreStatus) -> Result<(), RLBotError> {
         ffi::RLBotCoreStatus::Success => Ok(()),
         _ => Err(RLBotError { status }),
     }
-}
-
-#[allow(unused)]
-fn get_flatbuffer<'a, T: flatbuffers::Follow<'a> + 'a>(
-    byte_buffer: ffi::ByteBuffer,
-) -> Option<T::Inner> {
-    if byte_buffer.size == 0 {
-        return None;
-    }
-
-    let ptr = byte_buffer.ptr as *const u8;
-    let size = byte_buffer.size as usize;
-    // TODO: don't leak the buffer
-    let slice = unsafe { slice::from_raw_parts(ptr, size) };
-    Some(flatbuffers::get_root::<T>(slice))
 }
 
 #[cfg(test)]

--- a/src/packeteer.rs
+++ b/src/packeteer.rs
@@ -1,9 +1,6 @@
 #![allow(clippy::float_cmp)]
 
-use crate::{
-    ffi, ffi::LiveDataPacket, flat, game::GameTickPacket,
-    game_deserialize::deserialize_game_tick_packet, rlbot::RLBot,
-};
+use crate::{ffi, ffi::LiveDataPacket, flat, game::GameTickPacket, rlbot::RLBot};
 use std::{
     error::Error,
     time::{Duration, Instant},
@@ -42,7 +39,7 @@ impl<'a> Packeteer<'a> {
     /// crashed, and waiting longer will not help.
     #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Result<GameTickPacket, Box<dyn Error>> {
-        self.next_flatbuffer().map(deserialize_game_tick_packet)
+        self.next_flatbuffer().map(From::from)
     }
 
     /// Polls for the next unique [`GameTickPacket`].
@@ -50,7 +47,7 @@ impl<'a> Packeteer<'a> {
     /// If there is a packet that is newer than the previous packet, it is
     /// returned. Otherwise, `None` is returned.
     pub fn try_next(&mut self) -> Option<GameTickPacket> {
-        self.try_next_flat().map(deserialize_game_tick_packet)
+        self.try_next_flat().map(From::from)
     }
 
     /// Blocks until we receive the next unique [`ffi::LiveDataPacket`], and

--- a/src/rlbot.rs
+++ b/src/rlbot.rs
@@ -85,10 +85,7 @@ impl RLBot {
         // is loading. Wait for RoundActive to stabilize before trusting it.
         while count < 5 {
             let packet = packets.next_flatbuffer()?;
-            let is_round_active = packet
-                .gameInfo()
-                .map(|gi| gi.isRoundActive())
-                .unwrap_or_default();
+            let is_round_active = packet.game_info.is_round_active;
             if is_round_active {
                 count += 1;
             } else {


### PR DESCRIPTION
## BREAKING CHANGE

Fixes #25 a memory leak where the byte buffer passed from the RLBot interface library was never freed. This requires quite drastic internal change to how serialized flatbuffers are handled. Because it is now required to deserialize into our own types, this will break existing Rust bots.

### Concerns
 * The need to immediately deserialize to our own types will break existing bots.
 * There is an extra memory allocation and copy, so we can immediately free the ByteBuffer passed from the RLBot library.
 * External types `src/game.rs`
   * Can easily desync from their upstream ffi and flatbuffer types (`src/ffi.rs` and `src/rlbot_generated.rs`)
     * _Can this be automated?_
   * Are manually defined, instead of being derived from an upstream source.

I'm also open to rewriting this with a flatbuffer wrapper type that Deref's to the underlying flatbuffer type. I discarded this solution, because it means the wrapper has to carry around a reference to `RLBotCoreInterface::free()`. Overall, the current solution seems cleaner, at the expense of an allocation and a copy.