### PR TITLE
Fix rendering 3D strings and cleanup rendering example

### DIFF
--- a/examples/rendering.rs
+++ b/examples/rendering.rs
@@ -6,6 +6,8 @@
 
 use std::{error::Error, f32::consts::PI};
 
+const RADIUS: f32 = 250.0;
+
 fn main() -> Result<(), Box<dyn Error>> {
     let rlbot = rlbot::init()?;
 
@@ -25,35 +27,45 @@ fn main() -> Result<(), Box<dyn Error>> {
         total_ms -= sec * 1000;
         let min = total_ms / 1000 / 60;
 
-        let center_x = 100.0;
-        let center_y = 150.0;
+        let center_x = 0.0;
+        let center_y = -5120.0;
+        let center_z = 1540.0;
 
         let clock_hand = |fraction: f32, radius: f32| {
             let t = fraction * 2.0 * PI - PI / 2.0;
-            (center_x + t.cos() * radius, center_y + t.sin() * radius)
+            (
+                center_x + t.cos() * radius,
+                center_y,
+                center_z - t.sin() * radius,
+            )
         };
 
         let mut group = rlbot.begin_render_group(0);
         let green = group.color_rgb(0, 255, 0);
-        group.draw_string_2d(
-            (40.0, 20.0),
+        let text = format!("{}:{:02}.{:03}", min, sec, ms);
+        group.draw_string_3d(
+            (
+                center_x - 120.0 * text.len() as f32 / 2.0,
+                center_y,
+                center_z - RADIUS - 100.0,
+            ),
             (2, 2),
-            format!("{}:{:02}.{:03}", min, sec, ms),
+            text,
             green,
         );
-        group.draw_line_2d(
-            (center_x, center_y),
-            clock_hand(min as f32 / 60.0, 60.0),
+        group.draw_line_3d(
+            (center_x, center_y, center_z),
+            clock_hand(min as f32 / 60.0, RADIUS * 0.75),
             green,
         );
-        group.draw_line_2d(
-            (center_x, center_y),
-            clock_hand(sec as f32 / 60.0, 80.0),
+        group.draw_line_3d(
+            (center_x, center_y, center_z),
+            clock_hand(sec as f32 / 60.0, RADIUS),
             green,
         );
-        group.draw_line_2d(
-            (center_x, center_y),
-            clock_hand(ms as f32 / 1000.0, 40.0),
+        group.draw_line_3d(
+            (center_x, center_y, center_z),
+            clock_hand(ms as f32 / 1000.0, RADIUS / 2.0),
             green,
         );
         group.render()?;

--- a/src/init.rs
+++ b/src/init.rs
@@ -45,7 +45,7 @@ pub fn init() -> Result<RLBot, Box<dyn Error>> {
 /// [`examples/simple`]: https://github.com/whatisaphone/rlbot-rust/blob/master/examples/simple.rs
 #[allow(clippy::needless_pass_by_value)]
 pub fn init_with_options(options: InitOptions) -> Result<RLBot, Box<dyn Error>> {
-    let rlbot_dll_directory = options.rlbot_dll_directory.as_ref().map(PathBuf::as_path);
+    let rlbot_dll_directory = options.rlbot_dll_directory.as_deref();
 
     let dll = RLBotCoreInterface::load(rlbot_dll_directory)?;
     wait_for_initialized(&dll)?;

--- a/src/render.rs
+++ b/src/render.rs
@@ -247,7 +247,7 @@ impl<'a> RenderGroup<'a> {
         let text = self.builder.create_string(text.as_ref());
 
         let mut rm = flat::RenderMessageBuilder::new(&mut self.builder);
-        rm.add_renderType(flat::RenderType::DrawString2D);
+        rm.add_renderType(flat::RenderType::DrawString3D);
         rm.add_color(color);
         rm.add_start(&start);
         rm.add_scaleX(scale_x);

--- a/src/render.rs
+++ b/src/render.rs
@@ -123,6 +123,7 @@ impl<'a> RenderGroup<'a> {
     /// # let green = group.color_rgb(0, 255, 0);
     /// group.draw_line_2d((10.0, 10.0), (100.0, 100.0), green);
     /// ```
+    #[deprecated(note = "Drawing 2D lines is not currently supported")]
     pub fn draw_line_2d(
         &mut self,
         (x1, y1): (f32, f32),
@@ -178,6 +179,7 @@ impl<'a> RenderGroup<'a> {
     /// # let green = group.color_rgb(0, 255, 0);
     /// group.draw_line_2d_3d((10.0, 10.0), (100.0, 100.0, 100.0), green);
     /// ```
+    #[deprecated(note = "Drawing 2D-3D lines is not currently supported")]
     pub fn draw_line_2d_3d(
         &mut self,
         (x1, y1): (f32, f32),


### PR DESCRIPTION
Fix a bug in rendering, where 3D strings were treated as 2D strings. Depreciate 2D line rendering, as it is not currently supported by the RLBot interface. And get the rendering example working again with 3D lines.