### PR TITLE
Exposing the low-level interface of hivemind.

### DIFF
--- a/src/hive.rs
+++ b/src/hive.rs
@@ -84,7 +84,7 @@ pub fn run_hive<H: Hivemind>(mut hive: H) -> Result<(), Box<dyn Error>> {
 /// * `Ok(None)` – if the app was *not* launched by the framework.
 /// * `Err(_)` – if it appears the app was launched by the framework, but we
 ///   could not understand the arguments.
-pub(crate) fn parse_hive_framework_args() -> Result<Option<HiveFrameworkArgs>, ()> {
+pub fn parse_hive_framework_args() -> Result<Option<HiveFrameworkArgs>, ()> {
     parse_framework_command_line(env::args().skip(1))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@
 pub use crate::{
     framework::{parse_framework_args, run_bot, Bot, FrameworkArgs},
     game::*,
-    hive::{run_hive, Hivemind},
+    hive::{parse_hive_framework_args, run_hive, Hivemind, HiveFrameworkArgs},
     init::{init, init_with_options, InitOptions},
     match_settings::*,
     packeteer::Packeteer,


### PR DESCRIPTION
This has originaly been discussed when the hivemind code was merged. https://github.com/RLBot/rlbot-rust/pull/28#discussion_r389234279
And as the documentation says, there are different ways to use the framework. https://github.com/RLBot/rlbot-rust/blob/master/src/lib.rs#L19

I think that having a "low-level" and a "high-level" interface for hivemind, as we have for standard bots, would make things more coherent, and more flexible. Because right now, someone that is not using the high-level interface can't move over to a hivemind, due to the lack of access to the tools needed.
And finally, having access to the low-level interface doesn't change anything to the high-level one, so nothing's lost or changed ^^ .

What do you think?